### PR TITLE
Feature: Title field and improvements

### DIFF
--- a/src/TranslationHelper.php
+++ b/src/TranslationHelper.php
@@ -10,18 +10,28 @@ use craft\base\Model;
 
 use craft\base\Plugin;
 
+use craft\enums\PropagationMethod;
+use craft\errors\SiteNotFoundException;
 use craft\events\DefineFieldHtmlEvent;
 use craft\events\RegisterUrlRulesEvent;
 
-use craft\fields\Matrix;
+use craft\events\TemplateEvent;
 use craft\fields\PlainText;
 
+use craft\helpers\Cp;
 use craft\helpers\Json;
 use craft\helpers\StringHelper;
 
+use craft\models\Site;
 use craft\web\UrlManager;
 
+use craft\web\View;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 use yii\base\Event;
+use yii\base\Exception;
+use yii\base\InvalidConfigException;
 
 /**
  * Translation Helper plugin
@@ -42,21 +52,27 @@ class TranslationHelper extends Plugin
      */
     public bool $hasCpSection = false;
 
+    /**
+     * @return array[]
+     */
     public static function config(): array
     {
         return [
             'components' => [
-                    // Define component configs here...
+                // Define component configs here...
             ],
         ];
     }
 
+    /**
+     * @return void
+     */
     public function init(): void
     {
         parent::init();
 
         // Defer most setup tasks until Craft is fully initialized
-        Craft::$app->onInit(function() {
+        Craft::$app->onInit(function () {
             $this->attachEventHandlers();
         });
         if (Craft::$app->getRequest()->getIsCpRequest()) {
@@ -65,12 +81,23 @@ class TranslationHelper extends Plugin
         }
     }
 
-    
+    /**
+     * @return Model|null
+     * @throws InvalidConfigException
+     */
     protected function createSettingsModel(): ?Model
     {
         return Craft::createObject(Settings::class);
     }
 
+    /**
+     * @return string|null
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     * @throws Exception
+     * @throws InvalidConfigException
+     */
     protected function settingsHtml(): ?string
     {
         Craft::$app->getView()->registerAssetBundle(CPAssets::class);
@@ -79,64 +106,103 @@ class TranslationHelper extends Plugin
             'settings' => $this->getSettings(),
         ]);
     }
-    
 
+    /**
+     * @param $currentSiteId
+     * @return Site|null
+     * @throws SiteNotFoundException
+     */
+    private static function getOriginalSite($currentSiteId): ?Site
+    {
+        $settings = TranslationHelper::getInstance()->getSettings();
+        if (isset($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId])) {
+            return Craft::$app->sites->getSiteById($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId]);
+        }
+        return Craft::$app->sites->getPrimarySite();
+    }
+
+    /**
+     * @return void
+     */
     private function attachEventHandlers(): void
     {
+
+        // Register the event handler for the View::EVENT_AFTER_RENDER_TEMPLATE event
+        Event::on(
+            View::class,
+            View::EVENT_AFTER_RENDER_TEMPLATE,
+            function (TemplateEvent $event) {
+
+                if (!Craft::$app->getRequest()->getIsCpRequest() || !Cp::requestedSite()) {
+                    return;
+                }
+
+                /** @var View $sender */
+                $sender = $event->sender;
+
+                $currentSiteId = Cp::requestedSite()->getId();
+                $site = static::getOriginalSite($currentSiteId);
+
+                if (!$site || $site->id == $currentSiteId) {
+                    return;
+                }
+
+                // title field template
+                if (!isset($event->variables['id']) || $event->variables['id'] !== 'title') {
+                    return;
+                }
+
+                try {
+
+                    $elementUid = null;
+
+                    // convert the string event->sender->namespace string to an array e.g. "fields[title]" to ["fields", "title"]
+                    if (is_string($sender->namespace)) {
+                        $parts = explode('[', str_replace(']', '', $sender->namespace));
+                        // set $namespace to the last part of the array if it starts with "uid:"
+                        if (count($parts) > 0 && str_starts_with($parts[count($parts) - 1], 'uid:')) {
+                            $elementUid = explode(':', $parts[count($parts) - 1])[1] ?? null;
+                        }
+                    }
+
+                    // action request
+                    if (Craft::$app->getRequest()->getIsActionRequest()) {
+                        $elementId = Craft::$app->getRequest()->getParam('elementId') ?? null;
+                    } else {
+                        $vars = Craft::$app->getUrlManager()->parseRequest(Craft::$app->getRequest())[1] ?? [];
+                        $elementId = $vars['elementId'] ?? null;
+                    }
+
+                    if ($elementId || $elementUid) {
+                        Craft::$app->getView()->registerAssetBundle(CPAssets::class);
+                        $event->output .= "\n" . Craft::$app->view->renderTemplate('abm-translationhelper/_button.twig',
+                                ['isTitleField' => true, 'elementUid' => $elementUid, 'elementId' => $elementId, 'plainText' => true, 'original_site' => $site, 'hash' => StringHelper::UUID()]);
+                    }
+
+                } catch (\Exception $e) {
+                    return;
+                }
+
+            }
+        );
+
         Event::on(
             Field::class,
             Field::EVENT_DEFINE_INPUT_HTML,
-            static function(DefineFieldHtmlEvent $event) {
-                /** @var SettingsModel $settings */
-                
-                $settings = TranslationHelper::getInstance()->getSettings();
+            static function (DefineFieldHtmlEvent $event) {
+
                 $currentSiteId = $event->element->siteId;
-                $site = false;
 
                 switch ($event->sender->translationMethod) {
-                    case Field::TRANSLATION_METHOD_NONE: {
+                    case Field::TRANSLATION_METHOD_NONE:
+                    {
                         return;
-                    }break;
-
-                    case Field::TRANSLATION_METHOD_SITE: {
-                        if (isset($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId])) {
-                            $site = Craft::$app->sites->getSiteById($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId]);
-                        } else {
-                            $site = Craft::$app->sites->getPrimarySite();
+                    }
+                    default:
+                        {
+                            $site = static::getOriginalSite($currentSiteId);
                         }
-                    }break;
-
-                    case Field::TRANSLATION_METHOD_SITE_GROUP: {
-                        if (isset($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId])) {
-                            $site = Craft::$app->sites->getSiteById($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId]);
-                        } else {
-                            $site = Craft::$app->sites->getPrimarySite();
-                        }
-                    }break;
-
-                    case FIELD::TRANSLATION_METHOD_LANGUAGE: {
-                        if (isset($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId])) {
-                            $site = Craft::$app->sites->getSiteById($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId]);
-                        } else {
-                            $site = Craft::$app->sites->getPrimarySite();
-                        }
-                    }break;
-
-                    case FIELD::TRANSLATION_METHOD_CUSTOM: {
-                        if (isset($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId])) {
-                            $site = Craft::$app->sites->getSiteById($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId]);
-                        } else {
-                            $site = Craft::$app->sites->getPrimarySite();
-                        }
-                    }break;
-
-                    default: {
-                        if (isset($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId])) {
-                            $site = Craft::$app->sites->getSiteById($settings->selectedSiteGroups[Craft::$app->sites->getSiteById($currentSiteId)->groupId][$currentSiteId]);
-                        } else {
-                            $site = Craft::$app->sites->getPrimarySite();
-                        }
-                    }break;
+                        break;
                 }
 
                 if (!$site || $site->id == $currentSiteId) {
@@ -147,63 +213,73 @@ class TranslationHelper extends Plugin
                 $elementContext = $event->element->getFieldContext();
                 $contextArray = explode(":", $elementContext);
                 switch ($contextArray[0]) {
-                    case 'matrixBlockType': {
-                        if (isset($event->element->owner) && is_object($event->element->owner) && get_class($event->element->owner) == 'verbb\vizy\elements\Block') {
-                            return;
-                        }
-                        if ($event->element->uid) {
-                            $matrixElement = Craft::$app->elements->getElementByUid($event->element->uid, null, $currentSiteId);
-                            if ($matrixElement) {
-                                switch (Craft::$app->fields->getFieldById($matrixElement->fieldId)->propagationMethod) {
-                                    case Matrix::PROPAGATION_METHOD_NONE: {
-                                        return;
-                                    }break;
+                    case 'matrixBlockType':
+                        {
+                            if (isset($event->element->owner) && is_object($event->element->owner) && get_class($event->element->owner) == 'verbb\vizy\elements\Block') {
+                                return;
+                            }
+                            if ($event->element->uid) {
+                                $matrixElement = Craft::$app->elements->getElementByUid($event->element->uid, null, $currentSiteId);
+                                if ($matrixElement) {
+                                    switch (Craft::$app->fields->getFieldById($matrixElement->fieldId)->propagationMethod) {
+                                        case PropagationMethod::None:
+                                        {
+                                            return;
+                                        }
+                                    }
                                 }
                             }
                         }
-                    }break;
+                        break;
                 }
 
                 if (get_class($event->element) == 'verbb\vizy\elements\Block') {
                     return;
                 }
-                
-                $showTranslationHelperButton = false;
+
+                $plainText = get_class($event->sender) === PlainText::class;
+
                 switch (get_class($event->sender)) {
                     case 'abmat\tinymce\Field':
                     case 'craft\redactor\Field':
                     case 'craft\ckeditor\Field':
-                    case PlainText::class: {
-                        $showTranslationHelperButton = true;
-                    }break;
+                    case PlainText::class:
+                        {
+                        }
+                        break;
 
-                    default: {
+                    default:
+                    {
                         //asset
                         return;
-                    }break;
+                    }
                 }
 
-                if ($showTranslationHelperButton) {
-                    Craft::$app->getView()->registerAssetBundle(CPAssets::class);
-                    
-                    $event->html = $event->html . "\n" . Craft::$app->view->renderTemplate('abm-translationhelper/_button.twig',
-                        [ 'event' => $event, 'original_site' => $site, 'hash' => StringHelper::UUID()]);
-                }
+                Craft::$app->getView()->registerAssetBundle(CPAssets::class);
+                $event->html = $event->html . "\n" . Craft::$app->view->renderTemplate('abm-translationhelper/_button.twig',
+                        ['event' => $event, 'original_site' => $site, 'plainText' => $plainText, 'hash' => StringHelper::UUID()]);
+
             }
         );
     }
 
+    /**
+     * @return void
+     */
     private function _registerCpRoutes(): void
     {
         Event::on(
             UrlManager::class,
             UrlManager::EVENT_REGISTER_CP_URL_RULES,
-            function(RegisterUrlRulesEvent $event): void {
+            function (RegisterUrlRulesEvent $event): void {
                 $event->rules['abm-translationhelper/element/fetch'] = 'abm-translationhelper/element/fetch';
             }
         );
     }
 
+    /**
+     * @return void
+     */
     private function _registerTranslations(): void
     {
         $view = Craft::$app->getView();
@@ -213,7 +289,7 @@ class TranslationHelper extends Plugin
             'copied' => Craft::t('abm-translationhelper', 'Copied'),
             'close' => Craft::t('abm-translationhelper', 'Close'),
         ];
-        
+
         $view->registerJs('
 			if(typeof translations === "undefined") {translations = new Object();}
 			translations.abmtranslationhelper = ' . Json::encode($customTranslations) . ';

--- a/src/assets/ressources/dist/js/abm-translationhelper.js
+++ b/src/assets/ressources/dist/js/abm-translationhelper.js
@@ -1,72 +1,100 @@
 class AbmTranslationHelperClass {
 
-    constructor() {
+    constructor () {
     }
 
-    get_entry_text(btn, hud) {
-        if(typeof hud !== 'object')
-            return;
+    get_entry_text (btn, hud) {
+        if (typeof hud !== 'object')
+            return
 
-        var hudTarget = hud.target;
-        
-        var data = {
+        const hudTarget = hud.target
+
+        // plaintext fields?
+        const plaintext = Boolean(btn.getAttribute('data-plaintext'))
+
+        const data = {
+            // title fields
+            titlefield: Boolean(btn.getAttribute('data-titlefield')),
+            namespace: btn.getAttribute('data-namespace'),
+            // other elements
             elementid: btn.getAttribute('data-elementid'),
             elementuid: btn.getAttribute('data-elementuid'),
             originalsiteid: btn.getAttribute('data-originalsiteid'),
             elementcontext: btn.getAttribute('data-elementcontext'),
-            handle: btn.getAttribute('data-handle')
-        };
-        data[Craft.csrfTokenName] = Craft.csrfTokenValue;
+            handle: btn.getAttribute('data-handle'),
+            plaintext: plaintext,
+        }
 
-        Craft.postActionRequest("abm-translationhelper/element/fetch",data,$.proxy(function(response, textStatus) {
+        data[Craft.csrfTokenName] = Craft.csrfTokenValue
+
+        Craft.postActionRequest('abm-translationhelper/element/fetch', data, $.proxy(function (response, textStatus) {
             if (textStatus === 'success') {
                 // const data = JSON.parse(response);
-                const abmtranslationhelperModalContent = '<div class="hud-header">'+response.headline+'</div><textarea class="copyText" style="display: none;">'+response.value+'</textarea><div class="abmtranslationhelperHudBody body">'+response.value+'</div><div class="hud-footer"><div class="flex"><button class="btn copyClipboard">' + translations.abmtranslationhelper.copy_to_clipbard + '</button><button class="btn cancel abm-hud-closer">' + translations.abmtranslationhelper.close + '</button></div></div>';
-                hudTarget.updateBody(abmtranslationhelperModalContent);
-                hudTarget.updateSizeAndPosition(true);
+                const abmtranslationhelperModalContent = '<div class="hud-header">' + response.headline + '</div><div class="abmtranslationhelperHudBody body" style="white-space: pre-line">' + response.value + '</div><div class="hud-footer"><div class="flex"><button class="btn copyClipboard">' + translations.abmtranslationhelper.copy_to_clipbard + '</button><button class="btn cancel abm-hud-closer">' + translations.abmtranslationhelper.close + '</button></div></div>'
+                hudTarget.updateBody(abmtranslationhelperModalContent)
+                hudTarget.updateSizeAndPosition(true)
 
-                hud.target.$body[0].querySelector('button.abm-hud-closer').addEventListener("click", (evt) => {
-                    evt.preventDefault();
-                    hud.target.hide();
-                });
+                hud.target.$body[0].querySelector('button.abm-hud-closer').addEventListener('click', (evt) => {
+                    evt.preventDefault()
+                    hud.target.hide()
+                })
 
-                hud.target.$body[0].querySelector('div.hud-footer button.copyClipboard').addEventListener("click", (evt) => {
-                    const copyTextarea = hud.target.$body[0].querySelector('textarea.copyText');
-                    copyTextarea.style.display = '';
-                    copyTextarea.select();
-                    document.execCommand('copy');
-                    copyTextarea.style.display = 'none';
-                    
-                    //evt.target.textContent = translations.abmtranslationhelper.copied;
-                    alert(translations.abmtranslationhelper.copied_to_clipboard);
-                });
+                hud.target.$body[0].querySelector('div.hud-footer button.copyClipboard').addEventListener('click', async () => {
+
+                    const copyTextarea = hud.target.$body[0].querySelector('div.abmtranslationhelperHudBody.body')
+                    const copyText = plaintext ? copyTextarea.innerText : copyTextarea.innerHTML
+                    const type = plaintext ? 'text/plain' : 'text/html'
+                    const clipboardItemData = {
+                        [type]: copyText
+                    }
+                    const clipboardItem = new ClipboardItem(clipboardItemData)
+                    await navigator.clipboard.write([clipboardItem])
+
+                    alert(translations.abmtranslationhelper.copied_to_clipboard)
+
+                })
             } else {
-                console.error(xhr.statusText);
+                console.error(xhr.statusText)
             }
-        }, this));
+        }, this))
     }
-};
+}
 
-var AbmTranslationHelperObject = new AbmTranslationHelperClass();
+var AbmTranslationHelperObject = new AbmTranslationHelperClass()
 
+// Function to attach event handlers to translation helper buttons
+function attachTranslationHelperHandlers () {
 
-var $translationHelperButtons = document.querySelectorAll('button.abmtranslationhelper');
-$translationHelperButtons.forEach( (btn,index) => {
-    btn.addEventListener("click", (evt) => {
-        var btn = evt.target;
-        var $inner = btn.querySelector('#abmTranslationHud-'+btn.getAttribute('data-elementid'));
-        var hud = false;
-        hud = new Garnish.HUD(btn, $inner, {
-            orientations: ['top', 'bottom', 'right', 'left'],
-            onHide: function() {
-                return false;
-            },
-            onShow: function(hud) {
-                var btn = hud.target.$trigger[0];
-                AbmTranslationHelperObject.get_entry_text(btn, hud);
-            }
-        });
-        return false;
-        //
-    });
-});
+    const $translationHelperButtons = document.querySelectorAll('button.abmtranslationhelper:not([data-initialized="true"])')
+    $translationHelperButtons.forEach((btn) => {
+        btn.dataset.initialized = 'true'
+        btn.addEventListener('click', (evt) => {
+            const btn = evt.target
+            const $inner = btn.querySelector('#abmTranslationHud-' + btn.getAttribute('data-elementid'))
+            let hud = new Garnish.HUD(btn, $inner, {
+                orientations: ['top', 'bottom', 'right', 'left'],
+                onHide: function () {
+                    return false
+                },
+                onShow: function (hud) {
+                    var btn = hud.target.$trigger[0]
+                    AbmTranslationHelperObject.get_entry_text(btn, hud)
+                }
+            })
+            return false
+        })
+
+    })
+}
+
+// Watch for DOM changes to handle dynamically added buttons
+const observer = new MutationObserver(() => {
+    attachTranslationHelperHandlers()
+})
+
+observer.observe(document.body, {
+    childList: true,
+    subtree: true
+})
+
+attachTranslationHelperHandlers()

--- a/src/controllers/ElementController.php
+++ b/src/controllers/ElementController.php
@@ -2,64 +2,93 @@
 /**
  * @link https://abm.at
  * @copyright Copyright (c) abm Feregyhazy & Simon GmbH
-*/
+ */
 
 namespace abmat\translationhelper\controllers;
 
 use Craft;
-use craft\services\Elements;
+use craft\errors\InvalidFieldException;
 use craft\web\Controller;
+use yii\base\InvalidConfigException;
+use yii\web\MethodNotAllowedHttpException;
+use yii\web\Response;
 
 class ElementController extends Controller
 {
+
     /**
-     * @throws ForbiddenHttpException
+     * @param $originalSiteId
+     * @param $elementUid
+     * @param $elementId
+     * @return string
+     */
+    protected function getOriginalTitleFieldValue($originalSiteId, $elementUid, $elementId): string
+    {
+        // Determine whether to search by ID or UID
+        if (!empty($elementUid)) {
+            $originalElement = Craft::$app->elements->getElementByUid($elementUid, null, $originalSiteId);
+        } else {
+            $originalElement = Craft::$app->elements->getElementById($elementId, null, $originalSiteId);
+        }
+        // Find entry and get its title if exists
+        return $originalElement ? $originalElement->title : '';
+    }
+
+    /**
+     * @param $originalSiteId
+     * @param $handle
+     * @param $elementId
+     * @return string
+     * @throws InvalidFieldException
+     */
+    protected function getOriginalFieldValue($originalSiteId, $handle, $elementId): string
+    {
+        $originalElement = Craft::$app->elements->getElementById($elementId, null, $originalSiteId);
+        $value = '';
+        if ($originalElement) {
+            $value = $originalElement->getFieldValue($handle) ?? '';
+        }
+        return $value;
+    }
+
+    /**
+     * @return void|Response
+     * @throws InvalidConfigException
+     * @throws MethodNotAllowedHttpException
      */
     public function actionFetch()
     {
         $this->requirePostRequest();
-        
+
         $params = $this->request->getBodyParams();
 
-        $originalSite = Craft::$app->sites->getSiteById($params['originalsiteid']);
-        $originalElement = Craft::$app->elements->getElementById($params['elementid'], null, $params['originalsiteid']);
+        $isTitleField = isset($params['titlefield']) && filter_var($params['titlefield'], FILTER_VALIDATE_BOOLEAN) === true;
+        $plainText = isset($params['plaintext']) && filter_var($params['plaintext'], FILTER_VALIDATE_BOOLEAN) === true;
+        $originalSiteId = (int)$params['originalsiteid'];
+        $elementId = (int)$params['elementid'];
+        $elementUid = $params['elementuid'] ?? '';
+        $handle = $params['handle'] ?? '';
+
+        $originalSite = Craft::$app->sites->getSiteById($originalSiteId);
+
         $value = '';
-        if ($originalElement) {
-            $value = $originalElement->getFieldValue($params['handle']);
-        }
-        if ($value == null) {
-            $value = '';
-        }
-
-        /*
-        $elementContext = $params['elementcontext'];
-        if($elementContext == 'global') {
-            $originalElement = Craft::$app->elements->getElementById($params['elementid'], null, $params['originalsiteid']);
-            $value = $originalElement->getFieldValue($params['handle']);
-        }
-        else {
-            $contextArray = explode(":", $elementContext);
-            switch($contextArray[0]) {
-                case 'matrixBlockType': {
-                    $originalElement = Craft::$app->elements->getElementById($params['elementid'], null, $params['originalsiteid']);
-                    $value = $originalElement->getFieldValue($params['handle']);
-                }break;
-
-                default: {
-
-                }break;
+        try {
+            if ($isTitleField) {
+                $value = $this->getOriginalTitleFieldValue($originalSiteId, $elementUid, $elementId);
+            } else {
+                $value = $this->getOriginalFieldValue($originalSiteId, $handle, $elementId);
             }
-        }
-        */
+        } catch (\Exception $e) {
 
-        
+        }
+
         if (\Craft::$app->getRequest()->getAcceptsJson()) {
             return $this->asJson(
                 [
                     'headline' => Craft::t('abm-translationhelper', "Original text from '{siteName}'", [
-                        'siteName' => $originalSite->getName(),
-                    ]) . ':',
-                    'value' => $value,
+                            'siteName' => $originalSite->getName(),
+                        ]) . ':',
+                    'value' => $plainText ? htmlspecialchars($value) : $value,
                 ]
             );
         }

--- a/src/templates/_button.twig
+++ b/src/templates/_button.twig
@@ -1,21 +1,28 @@
 <div class="abmTranslationHelperContainer">
-    <button type="button" 
-        data-elementid="{{ event.element.id }}"
-        data-elementuid="{{ event.element.uid }}"
-        data-handle="{{ event.sender.handle }}"
-        data-originalsiteid="{{ original_site.id }}"
-        data-elementcontext="{{ event.element.getFieldContext }}"
-        data-hash="{{ hash }}"
-        title="{{ 'Show original text'|t('abm-translationhelper') }}"
-        class="btn abmtranslationhelper">
+    <button type="button"
+            {% if isTitleField is defined %}
+                data-titlefield="1"
+                data-elementid="{{ elementId }}"
+                data-elementuid="{{ elementUid }}"
+            {% else %}
+                data-elementid="{{ event.element.id }}"
+                data-elementuid="{{ event.element.uid }}"
+                data-handle="{{ event.sender.handle }}"
+                data-elementcontext="{{ event.element.getFieldContext }}"
+            {% endif %}
+            data-plaintext="{{ plainText }}"
+            data-originalsiteid="{{ original_site.id }}"
+            data-hash="{{ hash }}"
+            title="{{ 'Show original text'|t('abm-translationhelper') }}"
+            class="btn abmtranslationhelper">
 
         <span class="t9n-indicator" title="{{ 'Show original text'|t('abm-translationhelper') }}" data-icon="language" aria-label="{{ 'Show original text'|t('abm-translationhelper') }}" role="img"></span>
         {{ original_site.language }}
 
-        
+
     </button>
     <div class="hud_wrapper hidden">
-        <div id="abmTranslationHud-{{ event.element.id }}">
+        <div id="abmTranslationHud-{{ isTitleField is defined ? elementId : event.element.id }}">
             <div class="hud-footer">
                 <div class="flex">
                     <button class="btn copyClipboard">' + translations.abmtranslationhelper.copy_to_clipbard + '</button>


### PR DESCRIPTION
This feature also displays the translation button for title fields and improves the JavaScript handlers of the buttons with regard to “copy to clipboard” and the registration of the handlers if new buttons are inserted into the DOM.

Unfortunately, there is no HTML event for the title fields, so the general EVENT_AFTER_RENDER_TEMPLATE is used and various parameters are queried from the current request.
The original element is then obtained via the element ID or the UID in nested title fields.

The feature has so far only been tested with Craft 5.7.